### PR TITLE
FIX: wiki S&P500 listing

### DIFF
--- a/wikipedia/listing.py
+++ b/wikipedia/listing.py
@@ -7,7 +7,7 @@ class WikipediaStockListing:
     def read(self):
         url = 'https://en.wikipedia.org/wiki/List_of_S&P_500_companies'
         df = pd.read_html(url, header=0)[0]
-        cols_ren = {'Security':'Name', 'Ticker symbol':'Symbol', 'GICS Sector':'Sector', 'GICS Sub Industry':'Industry'}
+        cols_ren = {'Security':'Name', 'GICS Sector':'Sector', 'GICS Sub-Industry':'Industry'}
         df = df.rename(columns = cols_ren)
         df = df[['Symbol', 'Name', 'Sector', 'Industry']]
         df['Symbol'] = df['Symbol'].str.replace('\.', '')


### PR DESCRIPTION
Fix error incurred by changes in column name of the S&P500 table in Wikipedia page