### PR TITLE
Fix chart.py Typo

### DIFF
--- a/chart.py
+++ b/chart.py
@@ -57,7 +57,7 @@ def plot(df, start=None, end=None, **kwargs):
     * df: DataFrame to plot
     * start(default: None)
     * end(default: None)
-    * recent_high: display recent high price befre n-days (if recent_high == -1 plot plot recent high yesterday)
+    * recent_high: display recent high price befre n-days (if recent_high == -1 then plot recent high yesterday)
     '''
     try:
         from bokeh.plotting import figure, gridplot
@@ -87,7 +87,7 @@ def plot(df, start=None, end=None, **kwargs):
             df[f'MA_{n}'] = df.Close.rolling(n).apply(lambda prices: np.dot(prices, weights[:n])/weights[:n].sum())
         elif ma_type.upper() == 'EMA':
             df[f'MA_{n}'] = df.Close.ewm(span=n).mean()
-        elif ma_type.upper() == 'None':
+        elif ma_type.upper() == 'NONE':
             pass
         else:
             raise ValueError(f"moving_average_type '{ma_type}' is invalid")

--- a/investing/data.py
+++ b/investing/data.py
@@ -54,12 +54,12 @@ class InvestingDailyReader:
 
         if len(df) == 0:
             raise ValueError(f"Symbol('{symbol}'), Exchange('{exchange}') not found")
-        return df.iloc[0]['pairId']
+        return df.iloc[0]['pairId'], df.iloc[0]['industry']
 
     def read(self):
         start_date_str = self.start.strftime('%m/%d/%Y')
         end_date_str = self.end.strftime('%m/%d/%Y')
-        curr_id = self._get_currid_investing(self.symbol, self.exchange, self.data_source)
+        curr_id, exp_syms = self._get_currid_investing(self.symbol, self.exchange, self.data_source)
         if not curr_id:
             raise ValueError("Symbol unsupported or not found")
 
@@ -93,7 +93,7 @@ class InvestingDailyReader:
         if 'Volume' in df.columns:
             df['Volume'] = df['Volume'].apply(_convert_letter_to_num)
         df = df.sort_index()
-        exp_syms = ['US500', 'RUTNU', 'VIX', ] # exceptial symbols (vol == 0)
-        if 'Volume' in df.columns and self.symbol not in exp_syms:
+        
+        if 'Volume' in df.columns and exp_syms != 0:
             df = df[df['Volume'] > 0]
         return df


### PR DESCRIPTION
@FinanceData 

- 주석오타 및 이평선 안지워지는 문제 수정
- issue #96 수정 (exp_syms에 추가해서 해결가능하지만 로직변경으로 필요없어짐 )

pairId뽑을때 같은 컬럼에 있는 industry가 volume의 유뮤를 정하는 것 같음
exp_syms 용도변경 -> volume값이 없으면 0 그 외 다른 값 으로 표기됨

test code
```python
print('volume 유뮤 =',exp_syms!=0,', volume 평균 =', df['Volume'].mean())
```

test case
```python
fdr.DataReader('SPGSCLP', '2018-01-01', '2019-10-30') # issue 96
fdr.DataReader('MSCIEF', '2018-01-01', '2019-10-30') # issue 96
fdr.DataReader('US500', '2018-01-01', '2019-10-30') # exceptial symbols
fdr.DataReader('RUTNU', '2018-01-01', '2019-10-30') # exceptial symbols
fdr.DataReader('VIX', '2018-01-01', '2019-10-30') # exceptial symbols
fdr.DataReader('000150', '2018-01-01', '2019-10-30') 
fdr.DataReader('000150', '2018-01-01', '2019-10-30', exchange='KRX') 
fdr.DataReader('000150', '2018-01-01', '2019-10-30', exchange='SZSE') 
fdr.DataReader('000150', '2018-01-01', '2019-10-30', exchange='심천') 
fdr.DataReader('7203', '2020-01-01', exchange='TSE') 
fdr.DataReader('7203', '2020-01-01', exchange='TSE') 
fdr.DataReader('VCB', '2020-01-01', exchange='HOSE') 
fdr.DataReader('VIC', '2020-01-01', exchange='HOSE') 
fdr.DataReader('LNG', '2020-01-01', exchange='AMEX') 
fdr.DataReader('CBOE', '2020-01-01', exchange='AMEX') 
fdr.DataReader('601398', '2021-01-01', exchange='SSE')
fdr.DataReader('M2', data_source='fred')
fdr.DataReader('NASDAQCOM', data_source='fred')
fdr.DataReader('HSN1F', data_source='fred')
fdr.DataReader(['M2', 'NASDAQCOM'], data_source='fred') 
fdr.DataReader('601398', '2020-01-01', exchange='SSE')
fdr.DataReader('600519', '2020-01-01', exchange='SSE')
fdr.DataReader('000858', '2020-01-01', exchange='SZSE')
fdr.DataReader('000333', '2020-01-01', exchange='SZSE')
```

tes result
![image](https://user-images.githubusercontent.com/67433064/141830102-e8d8d11f-f775-4a12-8a96-36d492d43e23.png)


