### PR TITLE
update fdr.chart.plot function parameter to match BokehJS latest version

### DIFF
--- a/chart.py
+++ b/chart.py
@@ -102,8 +102,8 @@ def plot(df, start=None, end=None, **kwargs):
     height = params['height']
     if params['volume']:
         height = int(params['height'] - params['height'] * params['volume_height'])
-    pp = figure(plot_width=params['width'], 
-                plot_height=height,
+    pp = figure(width=params['width'], 
+                height=height,
                 x_range=(-1, min(120, len(df))),
                 y_range=(df.Low.min(), df.High.max()),
                 title=params['title'],


### PR DESCRIPTION
Document를 찾아본 결과,
BokehJS 2.4.3 에서는 plot_width, plot_height을 매개변수로 사용하지만,
BokehJS 3.0.2 에서는 삭제되었습니다.

본래 용도가 plot graph의 크기였으므로,

plot_width -> width
plot_height -> height 으로 변경하면 될 것 같습니다.

다른 PR을 확인해봤을때, 다른 graphing library로 변경될 예정으로 보이지만,
간단한 변경인 만큼, library 변경이 반영될때까지 적용해두면 좋을 것 같습니다.