### PR TITLE
fix: setup.py에서 path 찾을시 os.path.join 사용함

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with codecs.open(os.path(here, 'README.md'), encoding='utf-8') as f:
+with codecs.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
1. 기존코드 `with codecs.open(os.path(here, 'README.md'), encoding='utf-8') as f:` 는 실행시 아래 에러가 발생함.
![image](https://github.com/financedata-org/FinanceDataReader/assets/56215649/5e98a69f-d4ca-463c-99f5-d7c245a510c8)


2. `os.path.join` 사용하도록 코드 수정