### PR TITLE
docs: 한국 ETF 호출 방법에 대한 문서 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ krx_delisting = fdr.StockListing('KRX-DELISTING')
 # KRX stock delisting symbol list and names 관리종목 리스트
 krx_adm = fdr.StockListing('KRX-ADMINISTRATIVE') # 관리종목
 
+# ETF 데이터
+kr_etf = fdr.StockListing('ETF/KR') # 한국 ETF
+
 
 # FRED 데이터
 m2 = fdr.DataReader('M2', data_source='fred') #  M2통화량


### PR DESCRIPTION
README.md에서  `ETF/KR` 즉 한국시장에서 거래되는 `ETF`들을 호출하는 방법이 기재되어있지 않아 추가함.