### PR TITLE
Refactored deprecated method

### DIFF
--- a/fred/data.py
+++ b/fred/data.py
@@ -42,14 +42,14 @@ class FredReader:
                     df.replace('.', '', inplace=True)
                     df_list.append(df)
             merged = pd.concat(df_list, axis=1)
-            merged.fillna(method='ffill', inplace=True)
+            merged.ffill(inplace=True)
             return merged
 
         elif '.csv' in fname:
             df = pd.read_csv(url, parse_dates=['DATE'], na_values='.')
             df.set_index('DATE', inplace=True)
             df.replace('.', '', inplace=True)
-            df.fillna(method='ffill', inplace=True)
+            df.ffill(inplace=True)
             return df
         
         


### PR DESCRIPTION
변경 이유 :
FinanceDataReader/fred/data.py:45: FutureWarning: DataFrame.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.
  merged.fillna(method='ffill', inplace=True)
-> FutureWarning의 발생
변경 방식 :
df.fillna(method='ffill',inplace=True)
->
df.ffill(inplace=True)
